### PR TITLE
Update transaction names in Swagger hooks

### DIFF
--- a/swagger/hooks.js
+++ b/swagger/hooks.js
@@ -64,25 +64,25 @@ hooks.afterEach((transaction, done) => {
 
 // To test work with Gists and Stars in isolation, we need to add some prior
 // to certain HTTP transactions Dredd is about to make
-hooks.before('/gists/{id} > GET', (transaction, done) => {
+hooks.before('/gists/{id} > GET > 200 > application/json', (transaction, done) => {
   db.collection('gists').insert(gist, (err) => {
     done(err);
   });
 });
 
-hooks.before('/gists/{id} > PATCH', (transaction, done) => {
+hooks.before('/gists/{id} > PATCH > 200 > application/json', (transaction, done) => {
   db.collection('gists').insert(gist, (err) => {
     done(err);
   });
 });
 
-hooks.before('/gists > GET', (transaction, done) => {
+hooks.before('/gists > GET > 200 > application/json', (transaction, done) => {
   db.collection('gists').insert(gist, (err) => {
     done(err);
   });
 });
 
-hooks.before('/gists/{id}/star > GET', (transaction, done) => {
+hooks.before('/gists/{id}/star > GET > 200 > application/json', (transaction, done) => {
   db.collection('stars').insert(star, (err) => {
     done(err);
   });


### PR DESCRIPTION
Dredd 2.0 and higher uses different transaction names for Swagger - https://github.com/apiaryio/dredd/releases/tag/v2.0.0 Aim of this PR is to fix this:

<img width="313" alt="image" src="https://cloud.githubusercontent.com/assets/283441/20600431/f12d84fa-b253-11e6-8255-bb8e2baa203b.png">
