### PR TITLE
Add (experimental!) Windows-based CI builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ To learn how to use Dredd with your CI, read:
 | ---------- | ------ |
 | Travis CI  | [![Travis CI Build Status](https://travis-ci.org/apiaryio/dredd-example.svg?branch=master)](https://travis-ci.org/apiaryio/dredd-example) |
 | CircleCI   | [![CircleCI Build Status](https://circleci.com/gh/apiaryio/dredd-example.svg?style=svg)](https://circleci.com/gh/apiaryio/dredd-example) |
+| AppVeyor - [experimental][Windows Support]   | [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/7cqqqpnrlhd2dkg1?svg=true)](https://ci.appveyor.com/project/Apiary/dredd-example) |
 
 
 [CI]: https://en.wikipedia.org/wiki/Continuous_integration
@@ -33,3 +34,4 @@ To learn how to use Dredd with your CI, read:
 [API Blueprint]: http://apiblueprint.org/
 [Swagger]: https://swagger.io
 [API design life cycle]: https://apiary.io/how-to-build-api
+[Windows Support]: http://dredd.readthedocs.io/en/latest/installation/#windows-support

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+environment:
+  nodejs_version: "6"
+  LOG_LEVEL: silly
+services:
+  - "mongodb"
+install:
+  - ps: Install-Product node 6
+  - "npm -g install npm@latest"
+  - "set PATH=%APPDATA%\\npm;%PATH%"
+  - "npm install"
+build: off
+test_script:
+  - "node --version"
+  - "npm --version"
+  - "npm run test:api-blueprint"
+  - "taskkill /im node.exe /f"  # https://github.com/apiaryio/dredd/issues/669
+  - "npm run test:swagger"


### PR DESCRIPTION
Excerpt from the new docs introduced in https://github.com/apiaryio/dredd/pull/668:

> Windows support [is planned](https://github.com/apiaryio/dredd/issues/204). As an **experimental** prove that Dredd executes on Windows, the Dredd Example repository now features also one Windows-based CI, AppVeyor.