### PR TITLE
Removes deprecated options from "dredd.yml" files

### DIFF
--- a/apiblueprint/dredd.yml
+++ b/apiblueprint/dredd.yml
@@ -1,7 +1,6 @@
 dry-run: null
 hookfiles: ./apiblueprint/hooks.js
 language: nodejs
-sandbox: false
 server: npm start
 server-wait: 3
 init: false
@@ -17,9 +16,6 @@ inline-errors: false
 details: false
 method: []
 color: true
-level: info
-timestamp: false
-silent: false
 path: []
 hooks-worker-timeout: 5000
 hooks-worker-connect-timeout: 1500

--- a/openapi2/dredd.yml
+++ b/openapi2/dredd.yml
@@ -1,7 +1,6 @@
 dry-run: null
 hookfiles: ./openapi2/hooks.js
 language: nodejs
-sandbox: false
 server: npm start
 server-wait: 3
 init: false
@@ -17,9 +16,6 @@ inline-errors: false
 details: false
 method: []
 color: true
-level: info
-timestamp: false
-silent: false
 path: []
 hooks-worker-timeout: 5000
 hooks-worker-connect-timeout: 1500


### PR DESCRIPTION
Removes the usage of deprecated options in `dredd.yml`. See more details below.

## `level`

Please use `loglevel` for specifying the logging level. Omit the option to use the default logging level (`info` previously, `warn` in the latest release).

## `timestamp`

Please use `loglevel: debug` to include timestamps in logs. Omit the option for the `false` value.

## `silent`

Please use `loglevel: silent` to silence the log messages. Omit the option for the `false` value.

## `sandbox`

Sandbox support is deprecated. Please use [JS hooks](http://dredd.org/en/latest/hooks/index.html) instead.